### PR TITLE
add preference for timestamp display in info column

### DIFF
--- a/tapagg-arista.lua
+++ b/tapagg-arista.lua
@@ -8,6 +8,7 @@
 Arista = Proto ("arista", "Arista Networks")
 local a_proto = DissectorTable.new("arista", "Arista Networks")
 TapaggTimestamp = Proto ("arista.tapaggtimestamp", "TapAgg Header Timestamp")
+TapaggTimestampSubtree = Proto ("arista.tapaggtimestampsubtree", "TapAgg Header Timestamp Parent")
 UnknownSubtype = Proto ("arista.unknown", "Unknown Subtype")
 -- Arista Registered Ethertype
 local arista_ethertype = 0xd28b
@@ -22,7 +23,10 @@ Arista.fields = { a_subtype }
 -- TapAgg Timestamp Header has a version number and a timestamp
 local t_version = ProtoField.uint16 ("arista.timestamp.version", "Version", base.HEX)
 local t_ts = ProtoField.absolute_time("arista.tapaggtimestamp.timestamp", "Timestamp")
+local t_seconds = ProtoField.uint32("arista.timestamp.seconds", "Seconds")
+local t_nanoseconds = ProtoField.uint32("arista.timestamp.nanoseconds", "Nanoseconds")
 TapaggTimestamp.fields = { t_version, t_ts }
+TapaggTimestampSubtree.fields = { t_seconds, t_nanoseconds }
 
 -- Dissector for the Arista EtherType
 function Arista.dissector(buf, packet, tree)
@@ -93,6 +97,8 @@ function TapaggTimestamp.dissector(buf, packet, tree)
     local time = NSTime.new(seconds, nanoseconds)
     buf_len = sec_len + 4
     local ts = t:add(t_ts, buf(2,buf_len), time)
+    ts:add(t_seconds, buf(1,4), seconds)
+    ts:add(t_nanoseconds, buf(1,4), nanoseconds)
     return buf_len + 2
 end
 

--- a/tapagg-arista.lua
+++ b/tapagg-arista.lua
@@ -6,6 +6,7 @@
 -- ------------------------------------------------------
 
 Arista = Proto ("arista", "Arista Networks")
+Arista.prefs.timestamp_in_info = Pref.bool("Show TapAgg Timestamp in Info column", true, "")
 local a_proto = DissectorTable.new("arista", "Arista Networks")
 TapaggTimestamp = Proto ("arista.tapaggtimestamp", "TapAgg Header Timestamp")
 UnknownSubtype = Proto ("arista.unknown", "Unknown Subtype")
@@ -80,9 +81,11 @@ function TapaggTimestamp.dissector(buf, packet, tree)
     -- 4 bytes for nanoseconds
     ns_offset = 2 + sec_len
     local nanoseconds = buf(ns_offset,4):uint()
-    -- add the raw timestamp the info column
-    packet.cols.info = "TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " "
-    packet.cols.info:fence()
+    if Arista.prefs.timestamp_in_info then
+        -- add the raw timestamp the info column
+        packet.cols.info:set("TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " ")
+        packet.cols.info:fence()
+    end
     -- in the packet tree view show the time as a string
     -- compensate 48b timestamp seconds with local time upper 16b
     if sec_len == 2 then

--- a/tapagg-arista.lua
+++ b/tapagg-arista.lua
@@ -83,7 +83,7 @@ function TapaggTimestamp.dissector(buf, packet, tree)
     local nanoseconds = buf(ns_offset,4):uint()
     if Arista.prefs.timestamp_in_info then
         -- add the raw timestamp the info column
-        packet.cols.info:set("TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " ")
+        packet.cols.info:set(string.format("TapAgg Timestamp: %d.%09d ", seconds, nanoseconds))
         packet.cols.info:fence()
     end
     -- in the packet tree view show the time as a string


### PR DESCRIPTION
I've had a request to disable prepending the TapAgg Timestamp in the Info column, so the higher protocol information is more easily readable with limited screen real estate.  This PR adds a configurable preference item under Protocols -> Arista to enable/disable this functionality, with it defaulting to enabled (no change to default functionality).