### PR TITLE
add preference for timestamp display in info column

### DIFF
--- a/tapagg-arista.lua
+++ b/tapagg-arista.lua
@@ -6,6 +6,7 @@
 -- ------------------------------------------------------
 
 Arista = Proto ("arista", "Arista Networks")
+Arista.prefs.timestamp_in_info = Pref.bool("Show TapAgg Timestamp in Info column", true, "")
 local a_proto = DissectorTable.new("arista", "Arista Networks")
 TapaggTimestamp = Proto ("arista.tapaggtimestamp", "TapAgg Header Timestamp")
 UnknownSubtype = Proto ("arista.unknown", "Unknown Subtype")
@@ -80,9 +81,11 @@ function TapaggTimestamp.dissector(buf, packet, tree)
     -- 4 bytes for nanoseconds
     ns_offset = 2 + sec_len
     local nanoseconds = buf(ns_offset,4):uint()
-    -- add the raw timestamp the info column
-    packet.cols.info = "TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " "
-    packet.cols.info:fence()
+    if Arista.prefs.timestamp_in_info then
+        -- add the raw timestamp the info column
+        packet.cols.info:set("TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " ")
+        packet.cols.info:fence()
+    end
     -- in the packet tree view show the time as a string
     -- compensate 48b timestamp seconds with local time upper 16b
     if sec_len == 2 then

--- a/tapagg-arista.lua
+++ b/tapagg-arista.lua
@@ -83,7 +83,7 @@ function TapaggTimestamp.dissector(buf, packet, tree)
     local nanoseconds = buf(ns_offset,4):uint()
     if Arista.prefs.timestamp_in_info then
         -- add the raw timestamp the info column
-        packet.cols.info:set("TapAgg Timestamp: " .. seconds.."."..nanoseconds .. " ")
+        packet.cols.info:set(string.format("TapAgg Timestamp: %d.%09d ", seconds, nanoseconds))
         packet.cols.info:fence()
     end
     -- in the packet tree view show the time as a string


### PR DESCRIPTION
The default behavior of prepending the TapAgg Timestamp in the Info column makes it difficult to view the higher protocol information with limited screen real estate. 

This PR adds a configurable preference item under Protocols -> Arista to enable/disable this prepending functionality, with it defaulting to enabled (no change to default functionality).

Also fixes #4 